### PR TITLE
chore(config): remove deprecated dependabot config

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,8 +4,6 @@ updates:
     directory: /
     schedule:
       interval: daily
-    reviewers:
-      - arcjet/engineering-team
     groups:
       # Arcjet packages are grouped alone due to not being major/minor/patch yet
       arcjet-js:


### PR DESCRIPTION
Dependabot has deprecated using the `reviewers` config in favor of using CODEOWNERS.